### PR TITLE
Type Check fix

### DIFF
--- a/transcoder/test.py
+++ b/transcoder/test.py
@@ -40,7 +40,7 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(s.split(), ['hello', 'world'])
         # check that s.split fails when the separator is not a string
         with self.assertRaises(TypeError):
-            s.split(2)
+            s.split(2)  # type: ignore
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**FIX**:
Argument of type "Literal[2]" cannot be assigned to parameter "sep" of type "str | None" in function "split"
  Type "Literal[2]" cannot be assigned to type "str | None"
    "Literal[2]" is incompatible with "str"
    Type cannot be assigned to type "None"