### PR TITLE
add output type as an option for example shell scripts

### DIFF
--- a/examples/bin/fix.sh
+++ b/examples/bin/fix.sh
@@ -17,6 +17,10 @@
 # limitations under the License.
 #
 
+OUTPUT_TYPE=${1}
+
+[ -z ${OUTPUT_TYPE} ] && OUTPUT_TYPE=diag
+
 pushd ../..
 
 wget 'https://raw.githubusercontent.com/SunGard-Labs/fix2json/master/testfiles/42_order_single.txt'
@@ -28,6 +32,7 @@ python3 main.py \
   --factory fix \
   --source_file_format_type line_delimited \
   --continue_on_error \
+  --output_type ${OUTPUT_TYPE} \
   --message_type_inclusions NewOrderSingle
 
 rm 42_order_single.txt FIX42.xml

--- a/examples/bin/pcap.sh
+++ b/examples/bin/pcap.sh
@@ -17,6 +17,10 @@
 # limitations under the License.
 #
 
+OUTPUT_TYPE=${1}
+
+[ -z ${OUTPUT_TYPE} ] && OUTPUT_TYPE=diag
+
 pushd ../..
 
 wget 'ftp://ftp.cmegroup.com/SBEFix/Production/Templates/templates_FixBinary_v12.xml'
@@ -28,6 +32,7 @@ python3 main.py \
   --factory cme \
   --source_file_format_type pcap \
   --message_skip_bytes 16 \
+  --output_type ${OUTPUT_TYPE} \
   --message_type_inclusions SnapshotFullRefreshTCPLongQty68
 
 rm SnapshotFullRefreshTcpLongQty.pcap templates_FixBinary_v12.xml


### PR DESCRIPTION
example: `./fix.sh jsonl`. Defaults to `diag`