### PR TITLE
Changing default output directory

### DIFF
--- a/third_party/sbedecoder/message.py
+++ b/third_party/sbedecoder/message.py
@@ -323,6 +323,9 @@ class TypeMessageField(SBEMessageField):
 
         return _raw_value
 
+    def __repr__(self):
+        return self.name
+
 
 class SetMessageField(SBEMessageField):
     def __init__(self, name=None, original_name=None, id=None, description=None,  # pylint: disable=too-many-arguments

--- a/transcoder/message/ErrorWriter.py
+++ b/transcoder/message/ErrorWriter.py
@@ -56,7 +56,7 @@ class ErrorWriter:
 
         if output_path is None:
             rel_path = "errorOut"
-            main_script_dir = os.path.dirname(sys.argv[0])
+            main_script_dir = os.getcwd()
             self.output_path = os.path.join(main_script_dir, rel_path)
         else:
             self.output_path = output_path

--- a/transcoder/output/OutputManager.py
+++ b/transcoder/output/OutputManager.py
@@ -102,7 +102,7 @@ class OutputManager:
         """Creates the output path if it doesn't exist. Output path will be created as {output_path}/{relative_path}"""
         _output_path = None
         if output_path is None:
-            main_script_dir = os.path.dirname(sys.argv[0])
+            main_script_dir = os.getcwd()
             _output_path = os.path.join(main_script_dir, relative_path)
         else:
             _output_path = output_path


### PR DESCRIPTION
Since main.py was moved within the transcoder package, the default output folders were created within the transcoder package as well. Changing the default output to the current working directory.