### PR TITLE
Setup tools linting clean up

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,4 +21,4 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py') --fail-under=9
+        pylint $(git ls-files '*.py') --fail-under=9.9

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+        pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py') --fail-under=9

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,4 +21,4 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py') --fail-under=9.9
+        pylint $(git ls-files '*.py') --fail-under=10

--- a/.pylintrc
+++ b/.pylintrc
@@ -397,8 +397,8 @@ timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
 
 
 [REFACTORING]

--- a/.pylintrc
+++ b/.pylintrc
@@ -202,8 +202,7 @@ spelling-store-unknown-words=no
 
 # List of note tags to take in consideration, separated by a comma.
 notes=FIXME,
-      XXX,
-      TODO
+      XXX
 
 # Regular expression of note tags to take in consideration.
 notes-rgx=

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-from setuptools import setup
-
-if __name__ == "__main__":
-    pkg_vars = {}
-    with open("./transcoder/version.py", encoding="utf-8") as fp:
-        exec(fp.read(), pkg_vars)
-    setup(
-        version=pkg_vars['__version__']
-    )

--- a/transcoder/__init__.py
+++ b/transcoder/__init__.py
@@ -17,9 +17,10 @@
 # limitations under the License.
 #
 
+from enum import Enum
+
 from .version import __version__
 
-from enum import Enum
 
 # pylint: disable=invalid-name
 

--- a/transcoder/__init__.py
+++ b/transcoder/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/transcoder/__init__.py
+++ b/transcoder/__init__.py
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+from .version import __version__
+
 from enum import Enum
 
 # pylint: disable=invalid-name

--- a/transcoder/main.py
+++ b/transcoder/main.py
@@ -30,7 +30,7 @@ import argparse
 import logging
 import os
 
-from transcoder import LineEncoding
+from transcoder import __version__, LineEncoding
 from transcoder.message.MessageParser import MessageParser
 from transcoder.message.factory import all_supported_factory_types
 from transcoder.output import all_output_identifiers
@@ -137,12 +137,7 @@ def main():
                             help='The default logging level')
     arg_parser.add_argument('-q', '--quiet', action='store_true', help='Suppress message output to console')
 
-    # The relative path of an import would change based on executing the script directly versus from a packaged app
-    pkg_vars = {}
-    with open(f'{script_dir}/version.py', encoding="utf-8") as fp:
-        exec(fp.read(), pkg_vars)
-    version = pkg_vars['__version__']
-    arg_parser.add_argument('-v', '--version', action='version', version=f'Datacast Transcoder {version}')
+    arg_parser.add_argument('-v', '--version', action='version', version=f'Datacast Transcoder {__version__}')
 
     args = arg_parser.parse_args()
 

--- a/transcoder/main.py
+++ b/transcoder/main.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/transcoder/message/factory/ITCHMessageFactory.py
+++ b/transcoder/message/factory/ITCHMessageFactory.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/transcoder/message/factory/ITCHMessageFactory.py
+++ b/transcoder/message/factory/ITCHMessageFactory.py
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+# pylint: disable=invalid-name
+
 import struct
 
 from third_party.sbedecoder import SBEMessageFactory

--- a/transcoder/version.py
+++ b/transcoder/version.py
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-__version__ = '1.0.0'
+__version__ = '1.0.4'

--- a/transcoder/version.py
+++ b/transcoder/version.py
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-__version__ = '1.0.4'
+__version__ = '1.0.0'


### PR DESCRIPTION
- Resolved linter issues with missing packages
- Resolved linter issues related to version.py and removed setup.py
- GitHub Check now requires a perfect score for the linting check to pass
- Disabled "TODO" warnings in lint pylintrc
- Lint result on GitHub should now produce the same result as running locally
- Removed Python 3.8 from GitHub checks