### PR TITLE
Variable integer group fix

### DIFF
--- a/third_party/sbedecoder/message.py
+++ b/third_party/sbedecoder/message.py
@@ -315,9 +315,12 @@ class TypeMessageField(SBEMessageField):
         start_index = self.msg_offset + self.relative_offset + self.field_offset
         end_index = start_index + self.field_length
 
-        _, primitive_type_size = TypeMap.primitive_type_map[self.primitive_type]
-        if self.is_int_type() and primitive_type_size != self.field_length:
-            _raw_value = int.from_bytes(self.msg_buffer[start_index: end_index], self.byte_order)
+        if self.primitive_type is not None:
+            _, primitive_type_size = TypeMap.primitive_type_map[self.primitive_type]
+            if self.is_int_type() and primitive_type_size != self.field_length:
+                _raw_value = int.from_bytes(self.msg_buffer[start_index: end_index], self.byte_order)
+            else:
+                _raw_value = unpack_from(self.unpack_fmt, self.msg_buffer, start_index)[0]
         else:
             _raw_value = unpack_from(self.unpack_fmt, self.msg_buffer, start_index)[0]
 

--- a/third_party/sbedecoder/message.py
+++ b/third_party/sbedecoder/message.py
@@ -315,13 +315,15 @@ class TypeMessageField(SBEMessageField):
         start_index = self.msg_offset + self.relative_offset + self.field_offset
         end_index = start_index + self.field_length
 
-        if self.primitive_type is not None:
+        variable_len_int_handled: bool = False;
+        # Handle variable length integers
+        if self.primitive_type is not None and self.primitive_type in TypeMap.primitive_type_map:
             _, primitive_type_size = TypeMap.primitive_type_map[self.primitive_type]
             if self.is_int_type() and primitive_type_size != self.field_length:
+                variable_len_int_handled = True;
                 _raw_value = int.from_bytes(self.msg_buffer[start_index: end_index], self.byte_order)
-            else:
-                _raw_value = unpack_from(self.unpack_fmt, self.msg_buffer, start_index)[0]
-        else:
+
+        if variable_len_int_handled is False:
             _raw_value = unpack_from(self.unpack_fmt, self.msg_buffer, start_index)[0]
 
         return _raw_value

--- a/third_party/sbedecoder/message.py
+++ b/third_party/sbedecoder/message.py
@@ -315,8 +315,8 @@ class TypeMessageField(SBEMessageField):
         start_index = self.msg_offset + self.relative_offset + self.field_offset
         end_index = start_index + self.field_length
 
-        variable_len_int_handled: bool = False;
         # Handle variable length integers
+        variable_len_int_handled: bool = False;
         if self.primitive_type is not None and self.primitive_type in TypeMap.primitive_type_map:
             _, primitive_type_size = TypeMap.primitive_type_map[self.primitive_type]
             if self.is_int_type() and primitive_type_size != self.field_length:

--- a/transcoder/Transcoder.py
+++ b/transcoder/Transcoder.py
@@ -228,9 +228,9 @@ class Transcoder:  # pylint: disable=too-many-instance-attributes
         """Process the schema specified at runtime"""
         spec_schemas = self.message_parser.process_schema()
         for schema in spec_schemas:
-            if len(schema.fields) == 0:
+            if self.output_manager.supports_zero_field_schemas() is False and len(schema.fields) == 0:
                 logging.info('Schema "%s" contains no field definitions, skipping schema creation', schema.name)
-                # continue
+                continue
 
             for handler in self.all_handlers:
                 if handler.supports_all_message_types is True \

--- a/transcoder/Transcoder.py
+++ b/transcoder/Transcoder.py
@@ -24,12 +24,11 @@ import logging
 import os
 import signal
 import sys
-
 from datetime import datetime
 
-from transcoder.message.MessageUtil import get_message_parser, parse_handler_config
 from transcoder.message import DatacastParser, NoParser
 from transcoder.message.ErrorWriter import ErrorWriter, TranscodeStep
+from transcoder.message.MessageUtil import get_message_parser, parse_handler_config
 from transcoder.output import get_output_manager
 from transcoder.source import get_message_source
 
@@ -231,7 +230,7 @@ class Transcoder:  # pylint: disable=too-many-instance-attributes
         for schema in spec_schemas:
             if len(schema.fields) == 0:
                 logging.info('Schema "%s" contains no field definitions, skipping schema creation', schema.name)
-                continue
+                # continue
 
             for handler in self.all_handlers:
                 if handler.supports_all_message_types is True \

--- a/transcoder/output/OutputManager.py
+++ b/transcoder/output/OutputManager.py
@@ -39,6 +39,11 @@ class OutputManager:
         """Returns flag indicating if data writes are supported"""
         return True
 
+    @staticmethod
+    def supports_zero_field_schemas():
+        """Returns flag indicating if the output manager support schemas with zero fields"""
+        return False
+
     def __init__(self, schema_max_workers=5, lazy_create_resources: bool = False):
         self.schema_thread_pool_executor: ThreadPoolExecutor = concurrent.futures.ThreadPoolExecutor(
             max_workers=schema_max_workers)

--- a/transcoder/output/avro/BaseAvroOutputManager.py
+++ b/transcoder/output/avro/BaseAvroOutputManager.py
@@ -27,6 +27,11 @@ from transcoder.output.exception import OutputFunctionNotDefinedError
 class BaseAvroOutputManager(OutputManager):
     """Base avro output manager implementation. Used by both avro.io and fastavro implementations."""
 
+    @staticmethod
+    def supports_zero_field_schemas():
+        """Returns flag indicating if the output manager support schemas with zero fields"""
+        return True
+
     def __init__(self, prefix: str, output_path: str, lazy_create_resources: bool = False):
         super().__init__(lazy_create_resources=lazy_create_resources)
         self.prefix = prefix


### PR DESCRIPTION
- block_length_field definitions within groups do not contain a primitive_type which causes block_length field look ups to fail on groups.
- Added a check on the primitive_type field before getting the value from the map.
- Schemas with zero fields were excluded by default. Added a property to the output manager that allows this to be defined per output, and enabled it for the base Avro implementation for now.