### PR TITLE
Dump interim transcoder stats on SIGINFO

### DIFF
--- a/transcoder/Transcoder.py
+++ b/transcoder/Transcoder.py
@@ -48,6 +48,11 @@ class Transcoder:  # pylint: disable=too-many-instance-attributes,too-many-posit
                  fix_separator: int, base64: bool, base64_urlsafe: bool):
 
         signal.signal(signal.SIGINT, self.trap)
+        # SIGINFO (BSD/macOS `kill -s INFO`) and SIGUSR1 (Linux, same as `dd`)
+        # dump a non-destructive progress snapshot to stderr.
+        if hasattr(signal, 'SIGINFO'):
+            signal.signal(signal.SIGINFO, self.dump_progress)
+        signal.signal(signal.SIGUSR1, self.dump_progress)
 
         self.message_handler_spec = message_handlers
         self.message_handlers = {}
@@ -182,47 +187,62 @@ class Transcoder:  # pylint: disable=too-many-instance-attributes,too-many-posit
                 else:
                     self.message_handlers[supported_type] = [instance]
 
-    def print_summary(self):
-        """Print summary of the messages that were processed"""
-        if logging.getLogger().isEnabledFor(logging.INFO):
+    def print_summary(self, stream=None):
+        """Print summary of the messages that were processed.
+
+        When `stream` is set (SIGINFO/SIGUSR1), write the same snapshot there
+        even if the log level would otherwise hide it.
+        """
+        def emit(message, *args):
+            if stream is not None:
+                if args:
+                    message = message % args
+                print(message, file=stream, flush=True)
+            else:
+                logging.info(message, *args)
+
+        if stream is not None or logging.getLogger().isEnabledFor(logging.INFO):
+            if self.start_time is None:
+                emit('Transcode has not started yet')
+                return
             end_time = datetime.now()
             time_diff = end_time - self.start_time
             total_seconds = time_diff.total_seconds()
 
             if self.create_schemas_only is True:
-                logging.info('Run in create_schemas_only mode')
+                emit('Run in create_schemas_only mode')
 
             if self.output_manager.supports_data_writing() is False:
-                logging.info('Output manager \'%s\' does not support message writes',
+                emit('Output manager \'%s\' does not support message writes',
                              self.output_manager.output_type_identifier())
 
             if self.frame_only is False:
 
                 if self.message_parser.stats_only is True:
-                    logging.info('Run in stats_only mode')
+                    emit('Run in stats_only mode')
 
                 if self.sampling_count is not None:
-                    logging.info('Sampled messages: %s', self.sampling_count)
+                    emit('Sampled messages: %s', self.sampling_count)
 
                 if self.message_parser.message_type_inclusions is not None:
-                    logging.info('Message type inclusions: %s', self.message_parser.message_type_inclusions)
+                    emit('Message type inclusions: %s', self.message_parser.message_type_inclusions)
                 elif self.message_parser.message_type_exclusions is not None:
-                    logging.info('Message type exclusions: %s', self.message_parser.message_type_exclusions)
+                    emit('Message type exclusions: %s', self.message_parser.message_type_exclusions)
 
                 if self.create_schemas_only is False:
-                    logging.info('Source message count: %s', self.source.record_count)
-                    logging.info('Processed message count: %s', self.message_parser.record_count)
-                    logging.info('Transcoded message count: %s', self.transcoded_count)
-                    logging.info('Processed schema count: %s', self.message_parser.total_schema_count)
-                    logging.info('Summary of message counts: %s', self.message_parser.record_type_count)
-                    logging.info('Summary of error message counts: %s', self.message_parser.error_record_type_count)
-                    logging.info('Message rate: %s per second', round(self.source.record_count / total_seconds, 6))
+                    emit('Source message count: %s', self.source.record_count)
+                    emit('Processed message count: %s', self.message_parser.record_count)
+                    emit('Transcoded message count: %s', self.transcoded_count)
+                    emit('Processed schema count: %s', self.message_parser.total_schema_count)
+                    emit('Summary of message counts: %s', self.message_parser.record_type_count)
+                    emit('Summary of error message counts: %s', self.message_parser.error_record_type_count)
+                    emit('Message rate: %s per second', round(self.source.record_count / total_seconds, 6) if total_seconds else 0)
 
             else:
-                logging.info('Source record count: %s', self.source.record_count)
+                emit('Source record count: %s', self.source.record_count)
 
-            logging.info('Total runtime in seconds: %s', round(total_seconds, 6))
-            logging.info('Total runtime in minutes: %s', round(total_seconds / 60, 6))
+            emit('Total runtime in seconds: %s', round(total_seconds, 6))
+            emit('Total runtime in minutes: %s', round(total_seconds / 60, 6))
 
     def process_schemas(self):
         """Process the schema specified at runtime"""
@@ -254,6 +274,10 @@ class Transcoder:  # pylint: disable=too-many-instance-attributes,too-many-posit
 
         if self.continue_on_error is False:
             raise exception
+
+    def dump_progress(self, _signum, _frame):
+        """Print interim I/O stats to stderr and resume (SIGINFO / SIGUSR1)."""
+        self.print_summary(stream=sys.stderr)
 
     def trap(self, _signum, _frame):
         """Trap SIGINT to suppress noisy stack traces and show interim summary"""


### PR DESCRIPTION
You could already get a summary by interrupting the process, but that stops the run. This matches `dd`: `kill -s INFO` (macOS/BSD) or `SIGUSR1` (Linux) prints the current source/processed/transcoded counts to stderr and keeps going.

SIGINT still prints a summary and exits.

Fixes #111