### PR TITLE
Update stale URLs in existing examples, add new secdef streaming example

### DIFF
--- a/examples/bin/fix.sh
+++ b/examples/bin/fix.sh
@@ -24,8 +24,8 @@ OUTPUT_TYPE=${1}
 
 pushd ../..
 
-wget 'https://raw.githubusercontent.com/SunGard-Labs/fix2json/master/testfiles/42_order_single.txt'
-wget 'https://raw.githubusercontent.com/SunGard-Labs/fix2json/master/dict/FIX42.xml'
+wget 'https://raw.githubusercontent.com/SunGard-Labs/fix2json/ref/heads/master/testfiles/42_order_single.txt'
+wget 'https://raw.githubusercontent.com/SunGard-Labs/fix2json/ref/heads/master/dict/FIX42.xml'
 
 txcode \
   --source_file 42_order_single.txt \

--- a/examples/bin/secdef-stream.sh
+++ b/examples/bin/secdef-stream.sh
@@ -25,18 +25,18 @@ OUTPUT_TYPE=${1}
 
 pushd ../..
 
-wget 'ftp://ftp.cmegroup.com/SBEFix/Production/Templates/templates_FixBinary.xml'
-wget 'https://github.com/Open-Markets-Initiative/omi-data-packets/raw/refs/heads/main/Cme/Mdp3.Sbe.v1.12/SnapshotFullRefreshTcpLongQty.Tcp.pcap'
+wget -q 'https://raw.githubusercontent.com/SunGard-Labs/fix2json/refs/heads/master/dict/FIX50SP2.CME.xml'
 
-txcode \
-  --source_file SnapshotFullRefreshTcpLongQty.Tcp.pcap  \
-  --schema_file templates_FixBinary.xml \
-  --factory cme \
-  --source_file_format_type pcap \
-  --message_skip_bytes 16 \
-  --output_type ${OUTPUT_TYPE} \
-  --message_type_inclusions SnapshotFullRefreshTCPLongQty68
+wget -q -O - ftp://ftp.cmegroup.com/SBEFix/Production/secdef.dat.gz|gunzip - | \
+    txcode \
+        --schema_file FIX50SP2.CME.xml \
+        --factory fix \
+        --source_file_format_type line_delimited \
+        --continue_on_error \
+        --output_type ${OUTPUT_TYPE} \
+        --message_type_inclusions SecurityDefinition,TradingSessionList
 
-rm SnapshotFullRefreshTcpLongQty.Tcp.pcap templates_FixBinary.xml
+rm FIX50SP2.CME.xml
 
 popd
+

--- a/examples/bin/secdef.sh
+++ b/examples/bin/secdef.sh
@@ -26,8 +26,8 @@ OUTPUT_TYPE=${1}
 pushd ../..
 
 wget -q -O - ftp://ftp.cmegroup.com/SBEFix/Production/secdef.dat.gz|gunzip - | head -10 > secdef.dat
-wget -q -O - ftp://ftp.cmegroup.com/SBEFix/Production/TradingSessionList.dat| head -10 >> secdef.dat
-wget -q 'https://raw.githubusercontent.com/SunGard-Labs/fix2json/master/dict/FIX50SP2.CME.xml'
+wget -q -O - ftp://ftp.cmegroup.com/SBEFix/Production/TradingSessionList.dat | head -10 >> secdef.dat
+wget -q 'https://raw.githubusercontent.com/SunGard-Labs/fix2json/refs/heads/master/dict/FIX50SP2.CME.xml'
 
 txcode \
   --source_file secdef.dat \


### PR DESCRIPTION
As part of reviewing #273, it was discovered that some examples contained stale references to remote objects. These have been updated, and a new example has been added that runs for a longer duration and streams `gunzip`'d FIX messages over FTP. 

